### PR TITLE
Moving from notebook backend to widget backend.

### DIFF
--- a/03_data_augmentation.ipynb
+++ b/03_data_augmentation.ipynb
@@ -29,7 +29,7 @@
     "import numpy as np\n",
     "import os\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "\n",
     "from downloaddata import fetch_data as fdata\n",

--- a/04_basic_registration.ipynb
+++ b/04_basic_registration.ipynb
@@ -129,7 +129,7 @@
    "source": [
     "import SimpleITK as sitk\n",
     "from downloaddata import fetch_data as fdata\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "import registration_gui as rgui\n",
     "\n",

--- a/06_registration_application.ipynb
+++ b/06_registration_application.ipynb
@@ -45,7 +45,7 @@
     "import os.path\n",
     "import copy\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "import gui\n",
     "import matplotlib.pyplot as plt\n",
     "\n",

--- a/07_segmentation_and_shape_analysis.ipynb
+++ b/07_segmentation_and_shape_analysis.ipynb
@@ -23,7 +23,7 @@
     "import SimpleITK as sitk\n",
     "import pandas as pd\n",
     "\n",
-    "%matplotlib notebook\n",
+    "%matplotlib widget\n",
     "\n",
     "import matplotlib.pyplot as plt\n",
     "import gui\n",

--- a/environment.yml
+++ b/environment.yml
@@ -14,4 +14,6 @@ dependencies:
   - nodejs
   - jupyterlab
   - SimpleITK>=1.2.0
+  - pip:
+    - ipympl
     

--- a/tests/requirements_testing.txt
+++ b/tests/requirements_testing.txt
@@ -8,4 +8,5 @@ ipywidgets
 numpy
 scipy
 pandas
+ipympl
 SimpleITK>=1.2.0


### PR DESCRIPTION
For interactive plotting in both jupyter notebooks and jupyter lab we
need to use the jupyter matplotlib backend.