### PR TITLE
Adding the pip dependency into the environment.yml.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - nodejs
   - jupyterlab
   - SimpleITK>=1.2.0
+  - pip
   - pip:
     - ipympl
     


### PR DESCRIPTION
Get rid of conda warning about implicitly installing pip. Now it is
installed explicitly.